### PR TITLE
Ignores untagged fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - cobra-extensions v0.2.0, 2024-04-25
+## [Unreleased]
+
+
+## [0.2.4] - cobra-extensions v0.2.4, 2024-06-12
+
+### Fixes
+
+- The `reflection` module panicked when reflecting fields with an interface type.
+
+
+## [0.2.3] - cobra-extensions v0.2.3, 2024-04-25
 
 ### Added
 
-- You can now tame the cobra with the `charmer` module; see `src/example/cmd/charmer.go`
-- Support for positional arguments (pass values to commands without named flags); see `src/example/cmd/hello.go`
+- You can now tame the cobra with the `charmer` module; see `example/cmd/charmer/charmer.go`
+- Support for positional arguments (pass values to commands without named flags); see `example/commands/hello.go`
 
 ### Changed
 

--- a/pkg/reflection/reflection.go
+++ b/pkg/reflection/reflection.go
@@ -1,9 +1,10 @@
 package reflection
 
 import (
+	"reflect"
+
 	"github.com/matzefriedrich/cobra-extensions/internal"
 	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
-	"reflect"
 )
 
 type commandReflector[T any] struct {
@@ -49,6 +50,9 @@ func (r *commandReflector[T]) ReflectCommandDescriptor(n T) CommandDescriptor {
 			isExportedField := field.PkgPath == ""
 
 			flagName := field.Tag.Get("flag")
+			if len(flagName) == 0 {
+				continue
+			}
 
 			fieldType := field.Type
 			if fieldType == reflect.TypeOf(abstractions.CommandName{}) {

--- a/pkg/reflection/reflection.go
+++ b/pkg/reflection/reflection.go
@@ -50,9 +50,6 @@ func (r *commandReflector[T]) ReflectCommandDescriptor(n T) CommandDescriptor {
 			isExportedField := field.PkgPath == ""
 
 			flagName := field.Tag.Get("flag")
-			if len(flagName) == 0 {
-				continue
-			}
 
 			fieldType := field.Type
 			if fieldType == reflect.TypeOf(abstractions.CommandName{}) {
@@ -94,16 +91,18 @@ func tryReflectArgumentsDescriptor(m ReflectedObject, target ArgumentsDescriptor
 	hasCommandArgs := false
 
 	m.EnumerateFields(func(index int, field ReflectedField) {
-		switch field.typeKind() {
+		fieldTypeKind := field.typeKind()
+		switch fieldTypeKind {
 		case reflect.String:
 			fallthrough
 		case reflect.Int64:
 			fallthrough
 		case reflect.Bool:
 			if hasCommandArgs {
-				descriptor := ArgumentDescriptor{typeKind: field.typeKind(), value: field.value, argumentIndex: index - 1}
+				descriptor := ArgumentDescriptor{typeKind: fieldTypeKind, value: field.value, argumentIndex: index - 1}
 				target.With(Args(descriptor))
 			}
+		case reflect.Interface:
 		case reflect.Struct:
 			if field.isType(abstractions.CommandArgs{}) {
 				compatible, ok := field.getInterfaceValue().(abstractions.CommandArgs)

--- a/pkg/typed_command_test.go
+++ b/pkg/typed_command_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"testing"
 )
 
@@ -32,12 +33,17 @@ func Test_CreateTypedCommand(t *testing.T) {
 	assert.Equal(t, "Hello World", instance.P1)
 }
 
+type logger struct {
+	w io.Writer
+}
+
 type testCommand2 struct {
 	testCommand1
 	name        abstractions.CommandName `flag:"test"`
 	P2          int64                    `flag:"param2"`
 	P3          int                      `flag:"p3"`
 	BooleanFlag bool                     `flag:"b"`
+	logger      logger
 }
 
 func Test_CreateTypedCommand_with_base_template(t *testing.T) {


### PR DESCRIPTION
The `reflection` module panicked when reflecting fields with an interface type; the `tryReflectArgumentsDescriptor` has been changed to do nothing.