### PR TITLE
Fix/set application name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.6] - cobra-extensions v0.2.6, 2024-08-27
+
+### Added
+
+- Adds the `NewRootCommand` helper method that can be used to create root `cobra.Command` objects with application name and description.
+
+### Changed
+
+- Changes the `NewCommandLineApplication` method to set the application name and description (required to generate proper completion scripts for apps)
+
+- Adopts changes to examples
 
 
 ## [0.2.5] - cobra-extensions v0.2.5, 2024-06-12

--- a/example/cmd/charmer/charmer.go
+++ b/example/cmd/charmer/charmer.go
@@ -9,7 +9,7 @@ import (
 func main() {
 
 	err :=
-		charmer.NewCommandLineApplication().
+		charmer.NewCommandLineApplication("charmer-example", "").
 			AddCommand(commands.CreateHelloCommand()).
 			AddGroupCommand(commands.CreateCryptCommand(), func(crypto charmer.CommandSetup) {
 				crypto.AddCommand(

--- a/example/cmd/simple/main.go
+++ b/example/cmd/simple/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/matzefriedrich/cobra-extensions/example/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/charmer"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,7 @@ import (
 
 func main() {
 
-	app := &cobra.Command{}
+	app := charmer.NewRootCommand("simple-example", "")
 
 	app.AddCommand(commands.CreateHelloCommand())
 

--- a/pkg/charmer/command_line_application.go
+++ b/pkg/charmer/command_line_application.go
@@ -6,10 +6,21 @@ type CommandLineApplication struct {
 	root *cobra.Command
 }
 
+// NewRootCommand Creates a new cobra.Command object to be used as the application root command.
+func NewRootCommand(name string, description string) *cobra.Command {
+	if len(name) == 0 {
+		panic("name is required")
+	}
+	return &cobra.Command{
+		Use:   name,
+		Short: description,
+	}
+}
+
 // NewCommandLineApplication Creates a new CommandLineApplication instance.
-func NewCommandLineApplication() *CommandLineApplication {
+func NewCommandLineApplication(name string, description string) *CommandLineApplication {
 	return &CommandLineApplication{
-		root: &cobra.Command{},
+		root: NewRootCommand(name, description),
 	}
 }
 


### PR DESCRIPTION
- Adds the `NewRootCommand` helper method to create root `cobra.Command` objects with the application name and description.
- Changes the `NewCommandLineApplication` method to set the application name and description (required to generate proper completion scripts for apps).