### PR TITLE
Removes google/uuid package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - cobra-extensions v0.5.1, 2025-05-27
+
+### Changed
+
+* Removes the `google/uuid` package dependency and replaces it with a custom thread-safe unique identifier generator (a simple incrementing sequence generator (`UidSequence`) that uses a mutex lock to ensure thread safety). So, instead of using UUID strings for command keys, the code now uses sequential numeric identifiers.
+
+
 ## [0.5.0] - cobra-extensions v0.5.0, 2025-05-26
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/matzefriedrich/cobra-extensions
 go 1.23.0
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/reflection/command_descriptor.go
+++ b/internal/reflection/command_descriptor.go
@@ -2,10 +2,11 @@ package reflection
 
 import (
 	"fmt"
-	"github.com/google/uuid"
+	"reflect"
+	"strconv"
+
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
-	"reflect"
 )
 
 // CommandDescriptor represents the metadata and configuration for a command, including its use, descriptions, flags, and arguments.
@@ -25,7 +26,7 @@ func (d *commandDescriptor) Key() string {
 	return d.key
 }
 
-// NewCommandDescriptor creates a new CommandDescriptor with specified use, short and long descriptions, flags and arguments.
+// NewCommandDescriptor creates a new CommandDescriptor with specified use, short and long descriptions, flags, and arguments.
 func NewCommandDescriptor(use string, short string, long string, flags []FlagDescriptor, arguments types.ArgumentsDescriptor) types.CommandDescriptor {
 	key := makeCommandKey(use)
 	return &commandDescriptor{
@@ -39,8 +40,8 @@ func NewCommandDescriptor(use string, short string, long string, flags []FlagDes
 }
 
 func makeCommandKey(use string) string {
-	id := uuid.New()
-	idString := id.String()[0:8]
+	id := globalUidSequence.Next()
+	idString := strconv.FormatUint(id, 10)
 	key := fmt.Sprintf("%s-%s", use, idString)
 	return key
 }

--- a/internal/reflection/uid_sequence.go
+++ b/internal/reflection/uid_sequence.go
@@ -1,0 +1,44 @@
+package reflection
+
+import (
+	"sync"
+)
+
+type UidSequence interface {
+	Next() uint64
+}
+
+type uidSequence struct {
+	value uint64
+	m     sync.RWMutex
+}
+
+var globalUidSequence UidSequence = &uidSequence{}
+
+type UidSequenceOption func(sequence *uidSequence)
+
+func WithInitialValue(value uint64) UidSequenceOption {
+	return func(sequence *uidSequence) {
+		sequence.value = value
+	}
+}
+
+func NewUidSequence(option ...UidSequenceOption) UidSequence {
+	instance := &uidSequence{
+		value: 0,
+		m:     sync.RWMutex{},
+	}
+	instance.m.Lock()
+	defer instance.m.Unlock()
+	for _, option := range option {
+		option(instance)
+	}
+	return instance
+}
+
+func (s *uidSequence) Next() uint64 {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.value++
+	return s.value
+}

--- a/internal/reflection/uid_sequence.go
+++ b/internal/reflection/uid_sequence.go
@@ -4,7 +4,10 @@ import (
 	"sync"
 )
 
+// UidSequence represents an interface for generating unique sequential identifiers.
 type UidSequence interface {
+
+	// Next generates the next unique sequential identifier in the sequence and returns it as an unsigned 64-bit integer.
 	Next() uint64
 }
 
@@ -13,16 +16,20 @@ type uidSequence struct {
 	m     sync.RWMutex
 }
 
+// globalUidSequence is a singleton instance of UidSequence used to generate globally unique sequential identifiers.
 var globalUidSequence UidSequence = &uidSequence{}
 
+// UidSequenceOption represents a functional option used to customize the behavior of an uidSequence instance.
 type UidSequenceOption func(sequence *uidSequence)
 
+// WithInitialValue returns an option function that sets the initial value for the given uidSequence to the provided unsigned 64-bit integer.
 func WithInitialValue(value uint64) UidSequenceOption {
 	return func(sequence *uidSequence) {
 		sequence.value = value
 	}
 }
 
+// NewUidSequence creates and returns a new UidSequence instance with optional customizable behavior through UidSequenceOptions.
 func NewUidSequence(option ...UidSequenceOption) UidSequence {
 	instance := &uidSequence{
 		value: 0,
@@ -36,6 +43,7 @@ func NewUidSequence(option ...UidSequenceOption) UidSequence {
 	return instance
 }
 
+// Next increments the sequence value in a thread-safe manner and returns the updated value.
 func (s *uidSequence) Next() uint64 {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/internal/reflection/uid_sequence_test.go
+++ b/internal/reflection/uid_sequence_test.go
@@ -1,0 +1,60 @@
+package reflection
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UidSequence_Next_Current_returns_initial_value_plus_one(t *testing.T) {
+
+	// Arrange
+	initialValue := uint64(0)
+	sut := NewUidSequence(WithInitialValue(initialValue))
+
+	// Act
+	actual := sut.Next()
+
+	// Assert
+	assert.Equal(t, uint64(initialValue+1), actual)
+}
+
+func Test_UidSequence_Next_concurrent(t *testing.T) {
+
+	// Arrange
+	sut := NewUidSequence()
+
+	const delta = 100
+
+	wg := sync.WaitGroup{}
+	identifiers := make(chan uint64, delta)
+
+	wg.Add(delta)
+
+	go func() {
+		for i := 0; i < delta; i++ {
+			go func() {
+				defer wg.Done()
+				duration := time.Duration(5 + rand.Intn(45))
+				time.Sleep(duration * time.Millisecond)
+				identifiers <- sut.Next()
+			}()
+		}
+	}()
+
+	// Act
+	wg.Wait()
+
+	// Assert
+	close(identifiers)
+
+	seen := make(map[uint64]struct{})
+	for id := range identifiers {
+		_, found := seen[id]
+		seen[id] = struct{}{}
+		assert.False(t, found)
+	}
+}


### PR DESCRIPTION
Removes the `google/uuid` package dependency and replaces it with a custom thread-safe unique identifier generator.