### PR TITLE
Adds proper support for command execution with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - cobra-extensions v0.6.0, 2025-09-24
+
+### Added
+
+* **Breaking changes:** Context-aware command execution: `TypedCommand.Execute` now accepts `context.Context`; `TypedCommand` implementations must be altered after upgrading to the latest version; call-sites are not affected.
+* Clean context handling within `CreateTypedCommand` (no external key/context plumbing).
+
+### Changed
+
+* `CommandLineApplication.Execute` now supports an optional context and calls `ExecuteContext`; if not provided, `Execute` is called instead.
+* All command implementations and call sites have been updated to pass and handle context.
+* The command execution flow is simplified to construct and execute handlers directly in the Cobra Run closure.
+
+### Removed
+
+* The `CommandDescriptor` key generation and usage (command key no longer needed).
+
+
 ## [0.5.3] - cobra-extensions v0.5.3, 2025-09-09
 
 * Bumps `github.com/spf13/cobra` from 1.9.1 to 1.10.1 [#22](https://github.com/matzefriedrich/cobra-extensions/pull/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `CommandLineApplication.Execute` now supports an optional context and calls `ExecuteContext`; if not provided, `Execute` is called instead.
 * All command implementations and call sites have been updated to pass and handle context.
 * The command execution flow is simplified to construct and execute handlers directly in the Cobra Run closure.
+* Bumps `github.com/spf13/pflag` from 1.0.9 to 1.0.10
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,9 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
-github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/reflection/command_descriptor.go
+++ b/internal/reflection/command_descriptor.go
@@ -1,9 +1,7 @@
 package reflection
 
 import (
-	"fmt"
 	"reflect"
-	"strconv"
 
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
@@ -11,7 +9,6 @@ import (
 
 // CommandDescriptor represents the metadata and configuration for a command, including its use, descriptions, flags, and arguments.
 type commandDescriptor struct {
-	key       string
 	use       string
 	short     string
 	long      string
@@ -21,29 +18,15 @@ type commandDescriptor struct {
 
 var _ types.CommandDescriptor = (*commandDescriptor)(nil)
 
-// Key returns the key string associated with the CommandDescriptor.
-func (d *commandDescriptor) Key() string {
-	return d.key
-}
-
 // NewCommandDescriptor creates a new CommandDescriptor with specified use, short and long descriptions, flags, and arguments.
 func NewCommandDescriptor(use string, short string, long string, flags []FlagDescriptor, arguments types.ArgumentsDescriptor) types.CommandDescriptor {
-	key := makeCommandKey(use)
 	return &commandDescriptor{
-		key:       key,
 		use:       use,
 		short:     short,
 		long:      long,
 		flags:     flags,
 		arguments: arguments,
 	}
-}
-
-func makeCommandKey(use string) string {
-	id := globalUidSequence.Next()
-	idString := strconv.FormatUint(id, 10)
-	key := fmt.Sprintf("%s-%s", use, idString)
-	return key
 }
 
 // BindFlags Binds the reflected flags configuration to the given *cobra.Command object.

--- a/pkg/charmer/command_line_application.go
+++ b/pkg/charmer/command_line_application.go
@@ -1,6 +1,8 @@
 package charmer
 
 import (
+	"context"
+
 	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
@@ -33,8 +35,12 @@ func NewCommandLineApplication(name string, description string) *CommandLineAppl
 }
 
 // Execute executes the root command of the CommandLineApplication.
-func (a *CommandLineApplication) Execute() error {
-	return a.root.Execute()
+func (a *CommandLineApplication) Execute(ctx context.Context) error {
+	if ctx == nil {
+		return a.root.Execute()
+	} else {
+		return a.root.ExecuteContext(ctx)
+	}
 }
 
 // AddCommand Adds one or more commands to the root command of the CommandLineApplication.

--- a/pkg/charmer/command_line_application_test.go
+++ b/pkg/charmer/command_line_application_test.go
@@ -1,12 +1,52 @@
 package charmer
 
 import (
+	"context"
+	"testing"
+
 	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
+
+func Test_CommandLineApplication_NewRootCommand(t *testing.T) {
+
+	// Arrange
+	const invalidRootCommandName = ""
+
+	actExpectPanic := func(act func()) (panicked bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		act()
+		return false
+	}
+
+	// Act
+	act := func() { _ = NewRootCommand(invalidRootCommandName, "") }
+	result := make(chan bool, 1)
+	go func() {
+		result <- actExpectPanic(act)
+	}()
+
+	// Assert
+	assert.True(t, <-result, "expected panic in goroutine creating root command")
+}
+
+func Test_CommandLineApplication_Execute_without_context_without_any_command_does_not_return_error(t *testing.T) {
+
+	// Arrange
+	sut := NewCommandLineApplication("test-app", "")
+
+	// Act
+	err := sut.Execute(nil)
+
+	// Assert
+	assert.NoError(t, err)
+}
 
 func Test_CommandLineApplication_Execute_without_any_command_does_not_return_error(t *testing.T) {
 
@@ -14,7 +54,7 @@ func Test_CommandLineApplication_Execute_without_any_command_does_not_return_err
 	sut := NewCommandLineApplication("test-app", "")
 
 	// Act
-	err := sut.Execute()
+	err := sut.Execute(t.Context())
 
 	// Assert
 	assert.NoError(t, err)
@@ -34,17 +74,17 @@ func Test_CommandLineApplication_Execute_smoke_test(t *testing.T) {
 	application.root.SetArgs([]string{"group", "test"})
 
 	// Act
-	err := application.Execute()
+	err := application.Execute(t.Context())
 
 	// Assert
 	assert.NoError(t, err)
 	assert.True(t, command.Executed())
 }
 
-type executeFunc func()
+type executeFunc func(_ context.Context)
 
 func noop() executeFunc {
-	return func() {}
+	return func(context.Context) {}
 }
 
 type testCommand struct {
@@ -58,9 +98,9 @@ func (t *testCommand) Executed() bool {
 	return t.executed
 }
 
-func (t *testCommand) Execute() {
+func (t *testCommand) Execute(ctx context.Context) {
 	t.executed = true
-	t.executeFunc()
+	t.executeFunc(ctx)
 }
 
 var _ types.TypedCommand = (*testCommand)(nil)

--- a/pkg/commands/markdown_command.go
+++ b/pkg/commands/markdown_command.go
@@ -1,13 +1,15 @@
 package commands
 
 import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+
 	"github.com/matzefriedrich/cobra-extensions/internal/utils"
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"log"
-	"os"
-	"path/filepath"
 )
 
 type markdownDocsCommand struct {
@@ -16,7 +18,7 @@ type markdownDocsCommand struct {
 	root             *cobra.Command
 }
 
-func (m *markdownDocsCommand) Execute() {
+func (m *markdownDocsCommand) Execute(_ context.Context) {
 
 	outputPath, _ := filepath.Abs(m.OutputFolderPath)
 

--- a/pkg/commands/markdown_command_test.go
+++ b/pkg/commands/markdown_command_test.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_MarkdownCommand_Execute_renders_multiple_files_if_folder_path_specified(t *testing.T) {
@@ -18,7 +19,7 @@ func Test_MarkdownCommand_Execute_renders_multiple_files_if_folder_path_specifie
 	app.SetArgs([]string{"markdown", "--output", os.TempDir()})
 
 	// Act
-	err := app.Execute()
+	err := app.ExecuteContext(t.Context())
 
 	// Assert
 	assert.NoError(t, err)

--- a/pkg/commands/typed_command.go
+++ b/pkg/commands/typed_command.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+
 	"github.com/matzefriedrich/cobra-extensions/internal/reflection"
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
@@ -15,10 +16,10 @@ type commandContextValue struct {
 type CommandOption func(cmd *cobra.Command)
 
 // run Binds argument and flag values and executes the command.
-func (c *commandContextValue) run(target *cobra.Command, args ...string) {
+func (c *commandContextValue) run(ctx context.Context, target *cobra.Command, args ...string) {
 	c.descriptor.UnmarshalFlagValues(target)
 	c.descriptor.UnmarshalArgumentValues(args...)
-	c.handler.Execute()
+	c.handler.Execute(ctx)
 }
 
 // CreateTypedCommand Creates a new typed command from the given handler instance.
@@ -27,13 +28,15 @@ func CreateTypedCommand[T types.TypedCommand](instance T, options ...func() Comm
 	reflector := reflection.NewCommandReflector[T]()
 	desc := reflector.ReflectCommandDescriptor(instance)
 
-	commandKey := desc.Key()
-
 	cmd := &cobra.Command{
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			v := cmd.Context().Value(commandKey).(*commandContextValue)
-			v.run(cmd, args...)
+			contextValue := &commandContextValue{
+				handler:    instance,
+				descriptor: desc,
+			}
+			ctx := cmd.Context()
+			contextValue.run(ctx, cmd, args...)
 		},
 	}
 
@@ -44,14 +47,6 @@ func CreateTypedCommand[T types.TypedCommand](instance T, options ...func() Comm
 
 	desc.BindArguments(cmd)
 	desc.BindFlags(cmd)
-
-	contextValue := &commandContextValue{
-		handler:    instance,
-		descriptor: desc,
-	}
-
-	ctx := context.WithValue(context.Background(), commandKey, contextValue)
-	cmd.SetContext(ctx)
 
 	return cmd
 }

--- a/pkg/commands/typed_command_test.go
+++ b/pkg/commands/typed_command_test.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"context"
+	"io"
+	"testing"
+
 	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"testing"
 )
 
 type testCommand1 struct {
@@ -13,7 +15,7 @@ type testCommand1 struct {
 	P1   string            `flag:"param1"`
 }
 
-func (t *testCommand1) Execute() {
+func (t *testCommand1) Execute(_ context.Context) {
 }
 
 func Test_CreateTypedCommand(t *testing.T) {
@@ -27,7 +29,7 @@ func Test_CreateTypedCommand(t *testing.T) {
 	app.AddCommand(cmd)
 
 	// Act
-	_ = app.Execute()
+	_ = app.ExecuteContext(t.Context())
 
 	// Assert
 	assert.Equal(t, "Hello World", instance.P1)
@@ -58,7 +60,7 @@ func Test_CreateTypedCommand_with_base_template(t *testing.T) {
 	app.AddCommand(cmd)
 
 	// Act
-	_ = app.Execute()
+	_ = app.ExecuteContext(t.Context())
 
 	// Assert
 	assert.Equal(t, "Hello World", instance.P1)
@@ -87,7 +89,7 @@ func Test_CreateTypedCommand_with_base_template_default_values(t *testing.T) {
 	app.AddCommand(cmd)
 
 	// Act
-	_ = app.Execute()
+	_ = app.ExecuteContext(t.Context())
 
 	// Assert
 	assert.Equal(t, expectedP1, instance.P1)
@@ -108,7 +110,7 @@ type testCommandArgs struct {
 	BooleanArgument bool
 }
 
-func (t *testCommandWithPositionalArgs) Execute() {
+func (t *testCommandWithPositionalArgs) Execute(_ context.Context) {
 
 }
 
@@ -126,7 +128,7 @@ func Test_CreateTypedCommand_with_positional_args(t *testing.T) {
 	app.AddCommand(cmd)
 
 	// Act
-	_ = app.Execute()
+	_ = app.ExecuteContext(t.Context())
 
 	// Assert
 	arguments := instance.Arguments
@@ -134,4 +136,45 @@ func Test_CreateTypedCommand_with_positional_args(t *testing.T) {
 	assert.Equal(t, "Hello", arguments.TextArgument)
 	assert.Equal(t, int64(5), arguments.NumericArgument)
 	assert.Equal(t, true, arguments.BooleanArgument)
+}
+
+func Test_NonRunnable_unsets_Run_and_RunE_fields(t *testing.T) {
+	// Arrange
+	sut := NonRunnable()
+	target := &cobra.Command{}
+
+	// Act
+	sut(target)
+
+	// Assert
+	assert.Nilf(t, target.Run, "Command should not have a Run function")
+	assert.Nilf(t, target.RunE, "Command should not have a RunE function")
+}
+
+type disabledCommand struct {
+	execute func()
+}
+
+func (d *disabledCommand) Execute(_ context.Context) {
+	d.execute()
+}
+
+var _ types.TypedCommand = (*disabledCommand)(nil)
+
+func Test_CreateTypedCommand_with_NonRunnable_disables_the_Execute_handler(t *testing.T) {
+	// Arrange
+	executed := false
+	instance := &disabledCommand{
+		execute: func() {
+			executed = true
+		},
+	}
+	sut := CreateTypedCommand(instance, NonRunnable)
+
+	// Act
+	sut.ExecuteContext(t.Context())
+
+	// Assert
+	assert.NotNil(t, sut)
+	assert.False(t, executed)
 }

--- a/pkg/types/base_command.go
+++ b/pkg/types/base_command.go
@@ -1,10 +1,12 @@
 package types
 
+import "context"
+
 // BaseCommand A base type for typed commands.
 type BaseCommand struct{}
 
 // Execute performs the primary action defined by the BaseCommand.
-func (c *BaseCommand) Execute() {
+func (c *BaseCommand) Execute(_ context.Context) {
 }
 
 var _ TypedCommand = (*BaseCommand)(nil)

--- a/pkg/types/base_command_test.go
+++ b/pkg/types/base_command_test.go
@@ -7,7 +7,7 @@ func Test_BaseCommand_Execute(t *testing.T) {
 	sut := BaseCommand{}
 
 	// Act
-	sut.Execute()
+	sut.Execute(t.Context())
 
 	// Assert
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,13 +1,14 @@
 package types
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
 type CommandDescriptor interface {
 	UnmarshalFlagValues(target *cobra.Command)
 	UnmarshalArgumentValues(args ...string)
-	Key() string
 	BindArguments(cmd *cobra.Command)
 	BindFlags(cmd *cobra.Command)
 }
@@ -31,7 +32,7 @@ type ArgumentsDescriptor interface {
 type TypedCommand interface {
 
 	// Execute runs the command, performing its specific action based on the implementation.
-	Execute()
+	Execute(ctx context.Context)
 }
 
 // CommandsSetupFunc defines a function type used to set up commands within a CommandSetup context.


### PR DESCRIPTION
* Adds a `context.Context` parameter to the `Execute` method of `TypedCommand` and `CommandlineApplication`; adopts changes to all usages
* Adds clean context handling in `CreateTypedCommand`
* Removes the command key (no longer needed)